### PR TITLE
FIX-7: set resource at executor info.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## master
+
+- FIX-8: Set disk resource to the default value if its unset.
+- FIX-7: Set mesos resources at executor info.
+
 ## v0.3.0
 
 - Add Redis Authentication Support

--- a/mesos/handle_offers.go
+++ b/mesos/handle_offers.go
@@ -46,6 +46,9 @@ func HandleOffers(offers *mesosproto.Event_Offers) error {
 		}
 
 		if getLabelValue("biz.aventer.mesos_compose.executor", cmd) != "" {
+			// FIX: https://github.com/AVENTER-UG/mesos-compose/issues/7
+			cmd.Executor.Resources = defaultResources(cmd)
+
 			accept.Accept.Operations = []mesosproto.Offer_Operation{{
 				Type: mesosproto.Offer_Operation_LAUNCH_GROUP,
 				LaunchGroup: &mesosproto.Offer_Operation_LaunchGroup{


### PR DESCRIPTION
FIX: https://github.com/AVENTER-UG/mesos-compose/issues/7

Set default mesos resources at executor info object.